### PR TITLE
Fix Hugo v0.138+ compatibility issues

### DIFF
--- a/themes/clean-landing/layouts/partials/css.html
+++ b/themes/clean-landing/layouts/partials/css.html
@@ -1,4 +1,4 @@
-{{- $inServerMode := .Site.IsServer }}
+{{- $inServerMode := hugo.IsServer }}
 {{- $sass         := "style.sass" }}
 {{- $cssTarget    := "css/style.css" }}
 {{- $cssOpts      := cond ($inServerMode) (dict "targetPath" $cssTarget "enableSourceMap" true) (dict "targetPath" $cssTarget "outputStyle" "compressed") }}

--- a/themes/clean-landing/layouts/partials/meta.html
+++ b/themes/clean-landing/layouts/partials/meta.html
@@ -1,4 +1,4 @@
-{{ template "_internal/google_analytics_async.html" . }}
+{{ template "_internal/google_analytics.html" . }}
 
 {{ partial "analytics.html" . }}
 <meta charset="utf-8">


### PR DESCRIPTION
- Replace deprecated .Site.IsServer with hugo.IsServer
- Replace deprecated _internal/google_analytics_async.html with _internal/google_analytics.html

These changes fix build errors with Hugo v0.138.0 and ensure compatibility with newer Hugo versions.